### PR TITLE
Move to new CSV files in source repo and remove "recovered" stats

### DIFF
--- a/app.js
+++ b/app.js
@@ -33,15 +33,15 @@ const influxdb = new influx.InfluxDB({
 });
 
 
-const statType = ['Confirmed', 'Deaths', 'Recovered'];
+const statType = ['Confirmed', 'Deaths'];
 
 let covidConfirmed;
 let covidDeaths;
 let covidRecovered;
 
 function getCovidData(item) {
-
-    const url = "https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_19-covid-" + item + ".csv";
+    
+    const url = "https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_" + item.toLowerCase() + "_global.csv";
 
     return axios.get(url);
 }
@@ -113,7 +113,6 @@ function covidDB() {
 
         const zeilenConfirmed = Object.entries(covidConfirmed[i]);
         const zeilenDeaths = Object.entries(covidDeaths[i]);
-        const zeilenRecovered = Object.entries(covidRecovered[i]);
 
         let state = zeilenConfirmed[0][1];
         let country = zeilenConfirmed[1][1];
@@ -127,12 +126,10 @@ function covidDB() {
         for (let j = 4; j < anzahlEintrag; j++) {
             let zeileConfirmed = Object.values(zeilenConfirmed[j])
             let zeileDeaths = Object.values(zeilenDeaths[j])
-            let zeileRecovered = Object.values(zeilenRecovered[j])
 
             let timestemp = zeileConfirmed[0];
             let confirmed = zeileConfirmed[1];
             let deaths = zeileDeaths[1];
-            let recovered = zeileRecovered[1];
 
             if (confirmed == undefined) {
                 confirmed = Object.values(zeilenConfirmed[j - 1])[1];
@@ -141,9 +138,7 @@ function covidDB() {
             if (deaths == undefined) {
                 deaths = Object.values(zeilenDeaths[j - 1])[1];
             }
-            if (recovered == undefined) {
-                recovered = Object.values(zeilenRecovered[j - 1])[1];
-            }
+
             series.push(
                 {
                     measurement: 'Corona',
@@ -156,7 +151,6 @@ function covidDB() {
                     fields: {
                         Confirmed: confirmed,
                         Deaths: deaths,
-                        Recovered: recovered,
                     },
                     timestamp: timestemp
                 });


### PR DESCRIPTION
The source CSV files are deprecated and are no longer receiving new data. We need to use the new "_global" files which unfortunately no longer contain the "recovered" statistics.

See https://github.com/CSSEGISandData/COVID-19/tree/master/csse_covid_19_data/csse_covid_19_time_series