### PR TITLE
Update Yemen name since stats.json stop using "Yemen (Rep.)"

### DIFF
--- a/ccp.json
+++ b/ccp.json
@@ -2241,7 +2241,7 @@
         "population_2018": 0
     },
     {
-        "country_name": "Yemen (Rep.)",
+        "country_name": "Yemen",
         "country_code_2": "YE",
         "country_code_3": "YEM",
         "latitude": 15.552727,


### PR DESCRIPTION
On 2020/04/11, stats.json stop using the name "Yemen (Rep.)" causing an error when parsing the file.